### PR TITLE
open terminal buffer in terminal mode

### DIFF
--- a/lua/gh_dash/init.lua
+++ b/lua/gh_dash/init.lua
@@ -102,6 +102,8 @@ local function open_window()
     style = 'minimal',
     border = border,
   })
+
+  vim.cmd('startinsert')
 end
 
 function M.open()


### PR DESCRIPTION
No need to press an extra key to go into terminal mode once inside the `gh dash` floating window (`gh dash` keybinds will work immediately after popup opens).

Related to #3.